### PR TITLE
feat: fix broken numbers at the end of the string

### DIFF
--- a/src/jsonrepair.test.ts
+++ b/src/jsonrepair.test.ts
@@ -359,6 +359,13 @@ describe('jsonRepair', () => {
       strictEqual(jsonrepair('{"a":2\n"b":3\nc:4}'), '{"a":2,\n"b":3,\n"c":4}')
     })
 
+    it('should repair numbers at the end', () => {
+      strictEqual(jsonrepair('{"a":2.'), '{"a":2.0}')
+      strictEqual(jsonrepair('{"a":2e'), '{"a":2e0}')
+      strictEqual(jsonrepair('{"a":2e-'), '{"a":2e-0}')
+      strictEqual(jsonrepair('{"a":-'), '{"a":-0}')
+    })
+
     it('should repair missing colon between object key and value', () => {
       strictEqual(jsonrepair('{"a" "b"}'), '{"a": "b"}')
       strictEqual(jsonrepair('{"a" 2}'), '{"a": 2}')
@@ -451,12 +458,12 @@ describe('jsonRepair', () => {
     }, new JSONRepairError('Unexpected character "."', 3))
 
     throws(function () {
-      console.log({ output: jsonrepair('2e') })
-    }, new JSONRepairError("Invalid number '2e', expecting a digit but reached end of input", 2))
+      console.log({ output: jsonrepair('[2e,') })
+    }, new JSONRepairError("Invalid number '2e', expecting a digit but got ','", 2))
 
     throws(function () {
-      console.log({ output: jsonrepair('-') })
-    }, new JSONRepairError("Invalid number '-', expecting a digit but reached end of input", 2))
+      console.log({ output: jsonrepair('[-,') })
+    }, new JSONRepairError("Invalid number '-', expecting a digit but got ','", 2))
 
     throws(function () {
       console.log({ output: jsonrepair('foo [') })

--- a/src/jsonrepair.ts
+++ b/src/jsonrepair.ts
@@ -485,7 +485,9 @@ export function jsonrepair(text: string): string {
     const start = i
     if (text.charCodeAt(i) === codeMinus) {
       i++
-      expectDigit(start)
+      if (expectDigitOrAppendToEnd(start)) {
+        return true
+      }
     }
 
     if (text.charCodeAt(i) === codeZero) {
@@ -499,7 +501,9 @@ export function jsonrepair(text: string): string {
 
     if (text.charCodeAt(i) === codeDot) {
       i++
-      expectDigit(start)
+      if (expectDigitOrAppendToEnd(start)) {
+        return true
+      }
       while (isDigit(text.charCodeAt(i))) {
         i++
       }
@@ -510,7 +514,9 @@ export function jsonrepair(text: string): string {
       if (text.charCodeAt(i) === codeMinus || text.charCodeAt(i) === codePlus) {
         i++
       }
-      expectDigit(start)
+      if (expectDigitOrAppendToEnd(start)) {
+        return true
+      }
       while (isDigit(text.charCodeAt(i))) {
         i++
       }
@@ -600,6 +606,17 @@ export function jsonrepair(text: string): string {
     if (!isDigit(text.charCodeAt(i))) {
       const numSoFar = text.slice(start, i)
       throw new JSONRepairError(`Invalid number '${numSoFar}', expecting a digit ${got()}`, 2)
+    }
+  }
+
+  function expectDigitOrAppendToEnd(start: number, appendix = '0') {
+    if (i >= text.length) {
+      // repair numbers cut off at the end
+      output += text.slice(start, i) + appendix
+      return true
+    } else {
+      expectDigit(start)
+      return false
     }
   }
 

--- a/src/jsonrepair.ts
+++ b/src/jsonrepair.ts
@@ -485,7 +485,7 @@ export function jsonrepair(text: string): string {
     const start = i
     if (text.charCodeAt(i) === codeMinus) {
       i++
-      if (expectDigitOrAppendToEnd(start)) {
+      if (expectDigitOrRepair(start)) {
         return true
       }
     }
@@ -501,7 +501,7 @@ export function jsonrepair(text: string): string {
 
     if (text.charCodeAt(i) === codeDot) {
       i++
-      if (expectDigitOrAppendToEnd(start)) {
+      if (expectDigitOrRepair(start)) {
         return true
       }
       while (isDigit(text.charCodeAt(i))) {
@@ -514,7 +514,7 @@ export function jsonrepair(text: string): string {
       if (text.charCodeAt(i) === codeMinus || text.charCodeAt(i) === codePlus) {
         i++
       }
-      if (expectDigitOrAppendToEnd(start)) {
+      if (expectDigitOrRepair(start)) {
         return true
       }
       while (isDigit(text.charCodeAt(i))) {
@@ -609,10 +609,12 @@ export function jsonrepair(text: string): string {
     }
   }
 
-  function expectDigitOrAppendToEnd(start: number, appendix = '0') {
+  function expectDigitOrRepair(start: number) {
     if (i >= text.length) {
       // repair numbers cut off at the end
-      output += text.slice(start, i) + appendix
+      // this will only be called when we end after a '.', '-', or 'e' and does not
+      // change the number more than it needs to make it valid JSON
+      output += text.slice(start, i) + '0'
       return true
     } else {
       expectDigit(start)


### PR DESCRIPTION
When the string ends in the middle of a number, sometimes the JSON cannot be repaired.
This already works for simple sequences of digits, but this pull request adds the ability to also fix numbers if they end after a `.`, `e`, `e+` or `-`.
This doesn't change the numbers any more than when the sequence is truncated in mid-air, but keeps the "nature of the number" by appending a '0' in these cases.

 *  `1.` becomes `1.0`
 *  `1.e` becomes `1.e0`
 *  `-` becomes `-0`

and so on.