### PR TITLE
feat: turn invalid numbers into strings

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -443,13 +443,11 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
 
     test('should turn invalid numbers into strings', () => {
       expect(jsonrepair('ES2020')).toBe('"ES2020"')
-      // TODO: most of these still failing in parseRootEnd for streams: Error: Unexpected character "." at position 3
       expect(jsonrepair('0.0.1')).toBe('"0.0.1"')
       expect(jsonrepair('746de9ad-d4ff-4c66-97d7-00a92ad46967')).toBe('"746de9ad-d4ff-4c66-97d7-00a92ad46967"')
       expect(jsonrepair('234..5')).toBe('"234..5"')
       expect(jsonrepair('[0.0.1,2]')).toBe('["0.0.1",2]') // test delimiter for numerics
       expect(jsonrepair('[2 0.0.1 2]')).toBe('[2, "0.0.1 2"]') // note: currently spaces delimit numbers, but don't delimit unquoted strings
-      expect(jsonrepair('2.3.4')).toBe('"2.3.4"')
       expect(jsonrepair('2e3.4')).toBe('"2e3.4"')
     })
 

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -725,8 +725,13 @@ export function jsonrepairCore({
     const start = i
     if (input.charCodeAt(i) === codeMinus) {
       i++
-      if (expectDigitOrRepair(start)) {
+      if (atEndOfNumber()) {
+        repairNumberEndingWithNumericSymbol(start)
         return stack.update(Caret.afterValue)
+      }
+      if (!isDigit(input.charCodeAt(i))) {
+        i = start
+        return false
       }
     }
 
@@ -740,8 +745,13 @@ export function jsonrepairCore({
 
     if (input.charCodeAt(i) === codeDot) {
       i++
-      if (expectDigitOrRepair(start)) {
+      if (atEndOfNumber()) {
+        repairNumberEndingWithNumericSymbol(start)
         return stack.update(Caret.afterValue)
+      }
+      if (!isDigit(input.charCodeAt(i))) {
+        i = start
+        return false
       }
       while (isDigit(input.charCodeAt(i))) {
         i++
@@ -753,8 +763,13 @@ export function jsonrepairCore({
       if (input.charCodeAt(i) === codeMinus || input.charCodeAt(i) === codePlus) {
         i++
       }
-      if (expectDigitOrRepair(start)) {
+      if (atEndOfNumber()) {
+        repairNumberEndingWithNumericSymbol(start)
         return stack.update(Caret.afterValue)
+      }
+      if (!isDigit(input.charCodeAt(i))) {
+        i = start
+        return false
       }
       while (isDigit(input.charCodeAt(i))) {
         i++
@@ -843,24 +858,15 @@ export function jsonrepairCore({
     return prev
   }
 
-  function expectDigit(start: number) {
-    if (!isDigit(input.charCodeAt(i))) {
-      const numSoFar = input.substring(start, i)
-      throw new JSONRepairError(`Invalid number '${numSoFar}', expecting a digit ${got()}`, i)
-    }
+  function atEndOfNumber() {
+    return input.isEnd(i) || isDelimiter(input.charAt(i)) || isWhitespace(input.charCodeAt(i))
   }
 
-  function expectDigitOrRepair(start: number) {
-    if (input.isEnd(i)) {
-      // repair numbers cut off at the end
-      // this will only be called when we end after a '.', '-', or 'e' and does not
-      // change the number more than it needs to make it valid JSON
-      output.push(input.substring(start, i) + '0')
-      return true
-    } else {
-      expectDigit(start)
-      return false
-    }
+  function repairNumberEndingWithNumericSymbol(start: number) {
+    // repair numbers cut off at the end
+    // this will only be called when we end after a '.', '-', or 'e' and does not
+    // change the number more than it needs to make it valid JSON
+    output.push(input.substring(start, i) + '0')
   }
 
   function throwInvalidCharacter(char: string) {
@@ -886,11 +892,6 @@ export function jsonrepairCore({
   function throwInvalidUnicodeCharacter() {
     const chars = input.substring(i, i + 6)
     throw new JSONRepairError(`Invalid unicode character "${chars}"`, i)
-  }
-
-  function got(): string {
-    const char = input.charAt(i)
-    return char ? `but got '${char}'` : 'but reached end of input'
   }
 
   function atEndOfBlockComment(i: number) {

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -776,6 +776,12 @@ export function jsonrepairCore({
       }
     }
 
+    // if we're not at the end of the number by this point, allow this to be parsed as another type
+    if (!atEndOfNumber()) {
+      i = start
+      return false
+    }
+
     if (i > start) {
       // repair a number with leading zeros like "00789"
       const num = input.substring(start, i)


### PR DESCRIPTION
Fixes #120 

The changes here are within the number parsing logic:

- after parsing a numeric symbol (.-eE), if we're not at the end and the next char is not a digit, instead of throwing, fall back to trying to parse other types (in these cases, unquoted string).
- if we've already parsed a numeric symbol once and we've parsed through all the digits following that, instead of taking what's been parsed and assuming trailing alphanumerics are ok, fall back to trying to parse other types (again in this case, unquoted string).

Tests currently pass for regular but fail for streams (in parseRootEnd: Error: Unexpected character "." at position 3). Seems like it might just be an issue with properly updating the stack which I'm having a hard time figuring out. I could spend more time trying to understand but it seems worth asking - does anyone know what could be wrong with the code for streams here?

P.S.: thanks for the library! and the non-stream code was easy to follow 🔥 