### PR TITLE
feat: #126 #130 repair strings containing a colon or parenthesis

### DIFF
--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -12,7 +12,6 @@ import {
   codeLowercaseE,
   codeMinus,
   codeNewline,
-  codeOpenParenthesis,
   codeOpeningBrace,
   codeOpeningBracket,
   codePlus,
@@ -23,19 +22,20 @@ import {
   insertBeforeLastWhitespace,
   isControlCharacter,
   isDelimiter,
-  isDelimiterExceptSlash,
   isDigit,
   isDoubleQuote,
   isDoubleQuoteLike,
-  isFunctionName,
   isHex,
   isQuote,
   isSingleQuote,
   isSingleQuoteLike,
   isSpecialWhitespace,
   isStartOfValue,
+  isUnquotedStringDelimiter,
   isValidStringCharacter,
   isWhitespace,
+  regexFunctionNameChar,
+  regexFunctionNameCharStart,
   removeAtIndex,
   stripLastOccurrence
 } from '../utils/stringUtils.js'
@@ -126,7 +126,8 @@ export function jsonrepair(text: string): string {
       parseString() ||
       parseNumber() ||
       parseKeywords() ||
-      parseUnquotedString()
+      parseUnquotedString(false) ||
+      parseRegex()
     parseWhitespaceAndSkipComments()
 
     return processed
@@ -271,7 +272,7 @@ export function jsonrepair(text: string): string {
 
         skipEllipsis()
 
-        const processedKey = parseString() || parseUnquotedString()
+        const processedKey = parseString() || parseUnquotedString(true)
         if (!processedKey) {
           if (
             text.charCodeAt(i) === codeClosingBrace ||
@@ -507,7 +508,7 @@ export function jsonrepair(text: string): string {
 
           // repair unescaped quote
           str = `${str.substring(0, oQuote)}\\${str.substring(oQuote)}`
-        } else if (stopAtDelimiter && isDelimiter(text[i])) {
+        } else if (stopAtDelimiter && isUnquotedStringDelimiter(text[i])) {
           // we're in the mode to stop the string at the first delimiter
           // because there is an end quote missing
 
@@ -713,22 +714,25 @@ export function jsonrepair(text: string): string {
    * Repair a MongoDB function call like NumberLong("2")
    * Repair a JSONP function call like callback({...});
    */
-  function parseUnquotedString() {
+  function parseUnquotedString(isKey: boolean) {
     // note that the symbol can end with whitespaces: we stop at the next delimiter
     // also, note that we allow strings to contain a slash / in order to support repairing regular expressions
     const start = i
-    while (i < text.length && !isDelimiterExceptSlash(text[i]) && !isQuote(text.charCodeAt(i))) {
-      i++
-    }
 
-    if (i > start) {
-      if (
-        text.charCodeAt(i) === codeOpenParenthesis &&
-        isFunctionName(text.slice(start, i).trim())
-      ) {
+    if (regexFunctionNameCharStart.test(text[i])) {
+      while (i < text.length && regexFunctionNameChar.test(text[i])) {
+        i++
+      }
+
+      let j = i
+      while (isWhitespace(text.charCodeAt(j))) {
+        j++
+      }
+
+      if (text[j] === '(') {
         // repair a MongoDB function call like NumberLong("2")
         // repair a JSONP function call like callback({...});
-        i++
+        i = j + 1
 
         parseValue()
 
@@ -742,26 +746,52 @@ export function jsonrepair(text: string): string {
         }
 
         return true
-        // biome-ignore lint/style/noUselessElse: <explanation>
-      } else {
-        // repair unquoted string
-        // also, repair undefined into null
-
-        // first, go back to prevent getting trailing whitespaces in the string
-        while (isWhitespace(text.charCodeAt(i - 1)) && i > 0) {
-          i--
-        }
-
-        const symbol = text.slice(start, i)
-        output += symbol === 'undefined' ? 'null' : JSON.stringify(symbol)
-
-        if (text.charCodeAt(i) === codeDoubleQuote) {
-          // we had a missing start quote, but now we encountered the end quote, so we can skip that one
-          i++
-        }
-
-        return true
       }
+    }
+
+    while (
+      i < text.length &&
+      !isUnquotedStringDelimiter(text[i]) &&
+      !isQuote(text.charCodeAt(i)) &&
+      (!isKey || text[i] !== ':')
+    ) {
+      i++
+    }
+
+    if (i > start) {
+      // repair unquoted string
+      // also, repair undefined into null
+
+      // first, go back to prevent getting trailing whitespaces in the string
+      while (isWhitespace(text.charCodeAt(i - 1)) && i > 0) {
+        i--
+      }
+
+      const symbol = text.slice(start, i)
+      output += symbol === 'undefined' ? 'null' : JSON.stringify(symbol)
+
+      if (text.charCodeAt(i) === codeDoubleQuote) {
+        // we had a missing start quote, but now we encountered the end quote, so we can skip that one
+        i++
+      }
+
+      return true
+    }
+  }
+
+  function parseRegex() {
+    if (text[i] === '/') {
+      const start = i
+      i++
+
+      while (i < text.length && (text[i] !== '/' || text[i - 1] === '\\')) {
+        i++
+      }
+      i++
+
+      output += `"${text.substring(start, i)}"`
+
+      return true
     }
   }
 

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -12,6 +12,7 @@ import {
   codeLowercaseE,
   codeMinus,
   codeNewline,
+  codeOpenParenthesis,
   codeOpeningBrace,
   codeOpeningBracket,
   codePlus,

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -63,9 +63,12 @@ export function isDelimiter(char: string): boolean {
 }
 
 const regexDelimiter = /^[,:[\]/{}()\n+]$/
+const regexUnquotedStringDelimiter = /^[,[\]/{}\n+]$/
+export const regexFunctionNameCharStart = /^[a-zA-Z_$]$/
+export const regexFunctionNameChar = /^[a-zA-Z_$0-9]$/
 
-export function isDelimiterExceptSlash(char: string): boolean {
-  return isDelimiter(char) && char !== '/'
+export function isUnquotedStringDelimiter(char: string): boolean {
+  return regexUnquotedStringDelimiter.test(char)
 }
 
 export function isStartOfValue(char: string): boolean {

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -197,7 +197,3 @@ export function removeAtIndex(text: string, start: number, count: number) {
 export function endsWithCommaOrNewline(text: string): boolean {
   return /[,\n][ \t\r]*$/.test(text)
 }
-
-export function isFunctionName(text: string): boolean {
-  return /^\w+$/.test(text)
-}


### PR DESCRIPTION
Fixes #126 and #130.

This solution solves repairing unquotes strings that contain a colon `:`  or parenthesis `(` and `)`.

To do: try to refactor/simplify the new code a bit, and review it.