### PR TITLE
fix: repair unescaped double quotes followed by comma (issue #129)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -314,6 +314,21 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('["," 2')).toBe('[",", 2]')
     })
 
+    test('should escape unescaped double quotes followed by a comma (issue #129)', () => {
+      // Issue #129: unescaped double quotes followed by comma were incorrectly
+      // treated as end of string
+      expect(jsonrepair('{"a": "x "y", z"}')).toBe('{"a": "x \\"y\\", z"}')
+      expect(
+        jsonrepair('{"key": "become an "Airbnb-free zone", which is a political decision."}')
+      ).toBe('{"key": "become an \\"Airbnb-free zone\\", which is a political decision."}')
+      expect(jsonrepair('{"key": "test "quoted", more text"}')).toBe(
+        '{"key": "test \\"quoted\\", more text"}'
+      )
+
+      // Ensure normal cases still work
+      expect(jsonrepair('{"a": "x","b": "y"}')).toBe('{"a": "x","b": "y"}')
+    })
+
     test('should replace special white space characters', () => {
       expect(jsonrepair('{"a":\u00a0"foo\u00a0bar"}')).toBe('{"a": "foo\u00a0bar"}')
       expect(jsonrepair('{"a":\u202F"foo"}')).toBe('{"a": "foo"}')


### PR DESCRIPTION
## Summary

- Fixes issue where unescaped double quotes followed by a comma inside a string caused parsing to fail
- When encountering a quote followed by comma, the parser now looks ahead to check if what follows is a valid JSON value
- If not, it continues searching for the real end quote and escapes the current one

## Test plan

- [x] Added 4 new test cases for issue #129
- [x] All 134 existing tests pass
- [x] Lint checks pass

**Example:**

Before:
```javascript
jsonrepair('{"reason": "become an "Airbnb-free zone", which is a political decision."}')
// Error: Colon expected at position 70
```

After:
```javascript
jsonrepair('{"reason": "become an "Airbnb-free zone", which is a political decision."}')
// '{"reason": "become an \"Airbnb-free zone\", which is a political decision."}'
```

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)