### PR TITLE
fix: repair extra closing brace before root object continuation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -494,6 +494,22 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('{]')).toBe('{}')
     })
 
+    test('should repair an extra closing brace that closed the root object too early (#159)', () => {
+      // the reported example: one extra `}` after a valid nested object,
+      // followed by another root-level key/value pair
+      expect(jsonrepair('{"a":{"b":1}}},"c":2}')).toBe('{"a":{"b":1},"c":2}')
+      // simpler variant: single shallow extra close
+      expect(jsonrepair('{"a":1}},"b":2}')).toBe('{"a":1,"b":2}')
+      // multiple consecutive extra closes before the continuation
+      expect(jsonrepair('{"a":1}}}},"b":2}')).toBe('{"a":1,"b":2}')
+      // continuation value is itself an object
+      expect(jsonrepair('{"x":{"y":1}}},"z":{"w":2}}')).toBe('{"x":{"y":1},"z":{"w":2}}')
+      // multiple continuation entries after the premature close
+      expect(jsonrepair('{"a":1}},"b":2,"c":3}')).toBe('{"a":1,"b":2,"c":3}')
+      // whitespace around the extra closing brace
+      expect(jsonrepair('{"a":1} } , "b":2}')).toBe('{"a":1  , "b":2}')
+    })
+
     test('should add a missing closing bracket for an array', () => {
       expect(jsonrepair('[')).toBe('[]')
       expect(jsonrepair('[1,2,3')).toBe('[1,2,3]')

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -94,6 +94,25 @@ export function jsonrepair(text: string): string {
     output = stripLastOccurrence(output, ',')
   }
 
+  // repair premature root object close: an extraneous `}` closed the root
+  // object too early and more key-value pairs follow, e.g.
+  // `{"a":{"b":1}}},"c":2}` -> `{"a":{"b":1},"c":2}`. Un-close the root,
+  // skip the extraneous close brace(s), and resume parsing entries.
+  // Note: only handles object roots; array-root analogues (like
+  // `[1,2]],3]`) are out of scope since they do not appear in the reported
+  // cases and would need a separate recovery path.
+  while (text[i] === '}' && /\}\s*$/.test(output) && hasObjectContinuationAfterCloses(i)) {
+    // un-close root object (strip the closing `}` added by parseObject)
+    output = stripLastOccurrence(output, '}')
+    // skip all consecutive extraneous closing braces
+    while (text[i] === '}') {
+      i++
+      parseWhitespaceAndSkipComments()
+    }
+    // resume object body; expects a comma before the next key
+    parseObjectEntries(false)
+  }
+
   // repair redundant end quotes
   while (text[i] === '}' || text[i] === ']') {
     i++
@@ -106,6 +125,14 @@ export function jsonrepair(text: string): string {
   }
 
   throwUnexpectedCharacter()
+
+  function hasObjectContinuationAfterCloses(start: number): boolean {
+    let j = start
+    while (j < text.length && (text[j] === '}' || isWhitespace(text, j))) {
+      j++
+    }
+    return text[j] === ','
+  }
 
   function parseValue(): boolean {
     parseWhitespaceAndSkipComments()
@@ -277,74 +304,86 @@ export function jsonrepair(text: string): string {
         parseWhitespaceAndSkipComments()
       }
 
-      let initial = true
-      while (i < text.length && text[i] !== '}') {
-        let processedComma: boolean
-        if (!initial) {
-          processedComma = parseCharacter(',')
-          if (!processedComma) {
-            // repair missing comma
-            output = insertBeforeLastWhitespace(output, ',')
-          }
-          parseWhitespaceAndSkipComments()
-        } else {
-          processedComma = true
-          initial = false
-        }
-
-        skipEllipsis()
-
-        const processedKey = parseString() || parseUnquotedString(true)
-        if (!processedKey) {
-          if (
-            text[i] === '}' ||
-            text[i] === '{' ||
-            text[i] === ']' ||
-            text[i] === '[' ||
-            text[i] === undefined
-          ) {
-            // repair trailing comma
-            output = stripLastOccurrence(output, ',')
-          } else {
-            throwObjectKeyExpected()
-          }
-          break
-        }
-
-        parseWhitespaceAndSkipComments()
-        const processedColon = parseCharacter(':')
-        const truncatedText = i >= text.length
-        if (!processedColon) {
-          if (isStartOfValue(text[i]) || truncatedText) {
-            // repair missing colon
-            output = insertBeforeLastWhitespace(output, ':')
-          } else {
-            throwColonExpected()
-          }
-        }
-        const processedValue = parseValue()
-        if (!processedValue) {
-          if (processedColon || truncatedText) {
-            // repair missing object value
-            output += 'null'
-          } else {
-            throwColonExpected()
-          }
-        }
-      }
-
-      if (text[i] === '}') {
-        output += '}'
-        i++
-      } else {
-        // repair missing end bracket
-        output = insertBeforeLastWhitespace(output, '}')
-      }
+      parseObjectEntries(true)
 
       return true
     }
 
     return false
+  }
+
+  /**
+   * Parse the entries of an object (the sequence of key:value pairs and the
+   * closing `}`), assuming the opening `{` has already been consumed. When
+   * `isInitial` is true, the first entry is parsed without requiring a leading
+   * comma (the normal object-body behaviour). When `isInitial` is false, a
+   * comma is expected before the first entry — used by the top-level
+   * premature-close recovery to resume parsing after an extraneous `}`.
+   */
+  function parseObjectEntries(isInitial: boolean) {
+    let initial = isInitial
+    while (i < text.length && text[i] !== '}') {
+      let processedComma: boolean
+      if (!initial) {
+        processedComma = parseCharacter(',')
+        if (!processedComma) {
+          // repair missing comma
+          output = insertBeforeLastWhitespace(output, ',')
+        }
+        parseWhitespaceAndSkipComments()
+      } else {
+        processedComma = true
+        initial = false
+      }
+
+      skipEllipsis()
+
+      const processedKey = parseString() || parseUnquotedString(true)
+      if (!processedKey) {
+        if (
+          text[i] === '}' ||
+          text[i] === '{' ||
+          text[i] === ']' ||
+          text[i] === '[' ||
+          text[i] === undefined
+        ) {
+          // repair trailing comma
+          output = stripLastOccurrence(output, ',')
+        } else {
+          throwObjectKeyExpected()
+        }
+        break
+      }
+
+      parseWhitespaceAndSkipComments()
+      const processedColon = parseCharacter(':')
+      const truncatedText = i >= text.length
+      if (!processedColon) {
+        if (isStartOfValue(text[i]) || truncatedText) {
+          // repair missing colon
+          output = insertBeforeLastWhitespace(output, ':')
+        } else {
+          throwColonExpected()
+        }
+      }
+      const processedValue = parseValue()
+      if (!processedValue) {
+        if (processedColon || truncatedText) {
+          // repair missing object value
+          output += 'null'
+        } else {
+          throwColonExpected()
+        }
+      }
+    }
+
+    if (text[i] === '}') {
+      output += '}'
+      i++
+    } else {
+      // repair missing end bracket
+      output = insertBeforeLastWhitespace(output, '}')
+    }
   }
 
   /**

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -471,6 +471,27 @@ export function jsonrepairCore({
       return stack.update(Caret.afterValue)
     }
 
+    // repair premature root object close: an extraneous `}` closed the root
+    // object too early and more key-value pairs follow, e.g.
+    // `{"a":{"b":1}}},"c":2}` -> `{"a":{"b":1},"c":2}`. Un-close the root,
+    // skip the extraneous close brace(s), and resume parsing entries as if
+    // still inside the object.
+    if (
+      input.charAt(i) === '}' &&
+      output.endsWithIgnoringWhitespace('}') &&
+      hasObjectContinuationAfterCloses(i)
+    ) {
+      // un-close root object
+      output.stripLastOccurrence('}')
+      // skip all consecutive extraneous closing braces
+      while (input.charAt(i) === '}') {
+        i++
+        parseWhitespaceAndSkipComments()
+      }
+      // resume object body parsing; expects a comma before the next key
+      return stack.push(StackType.object, Caret.afterValue)
+    }
+
     // repair redundant end braces and brackets
     while (input.charAt(i) === '}' || input.charAt(i) === ']') {
       i++
@@ -481,6 +502,19 @@ export function jsonrepairCore({
       throwUnexpectedCharacter()
     }
 
+    return false
+  }
+
+  function hasObjectContinuationAfterCloses(start: number): boolean {
+    let j = start
+    while (!input.isEnd(j)) {
+      const ch = input.charAt(j)
+      if (ch === '}' || ch === ' ' || ch === '\n' || ch === '\t' || ch === '\r') {
+        j++
+      } else {
+        return ch === ','
+      }
+    }
     return false
   }
 


### PR DESCRIPTION
## Summary

Fixes #159.

`jsonrepair('{"a":{"b":1}}},"c":2}')` currently throws `Unexpected character "," at position 14`. After this change it returns `{"a":{"b":1},"c":2}` as expected.

## Root Cause

When the document has an extraneous `}` that closed the root object too early and more key-value pairs follow, `parseValue()` completes successfully on the premature close (it doesn't know the brace was extra), the subsequent `}` is consumed by the existing "redundant end quotes" loop, and then the `,` that begins the continuation trips `throwUnexpectedCharacter`. The parser had no handling for the "premature root close followed by continuation" pattern — only for trailing extras with no continuation (e.g. `{"a":1}}`).

## Changes

- **`src/regular/jsonrepair.ts`** — after `parseValue()` returns at the root, detect the pattern `text[i] === '}' && /\}\s*$/.test(output) && <lookahead reaches ','>`. When it matches, strip the trailing `}` from `output` (un-close the root), skip the consecutive extraneous `}` characters, and call `parseObjectEntries(false)` to resume parsing entries. The while-loop form handles multiple rounds of recovery for deeply nested cases. The whitespace-tolerant end check mirrors streaming's `endsWithIgnoringWhitespace('}')`.
- **`src/regular/jsonrepair.ts`** — extract the body of `parseObject`'s key/value loop into a new function `parseObjectEntries(isInitial: boolean)` so it can be reused by both `parseObject` (with `true`) and the top-level recovery path (with `false`, where a leading comma is expected before the next entry). This is a pure refactor — `parseObject` behaviour is unchanged.
- **`src/streaming/core.ts`** — mirror the recovery inside `parseRootEnd`. Uses `output.stripLastOccurrence('}')` + `stack.push(StackType.object, Caret.afterValue)` so the state machine resumes in the afterValue caret expecting a comma.
- **`src/index.test.ts`** — new test block "should repair an extra closing brace that closed the root object too early (#159)" with 6 assertions: the reported case, a simpler single-extra variant, multiple consecutive extras, continuation whose value is itself an object, multiple continuation entries, and the whitespace-between-braces variant.

Kept minimal: recovery is guarded on `output` ending with `}` (non-object roots unaffected), only activates when the lookahead actually finds `,` (no false positives for `{"a":1}}` at end-of-document), and re-uses existing object-body parsing rather than duplicating it.

## Testing

- [x] Full test suite: 158 → 160 passes, 0 regressions (new tests covered by `describe.each(implementations)` so they run against both regular + streaming implementations)
- [x] Specific bug reproduction from #159 — exact input `{"a":{"b":1}}},"c":2}` now returns `{"a":{"b":1},"c":2}`
- [x] `npm run lint` clean (biome)
- [x] `npm run build-and-test` green

```bash
npm run test:it
# Test Files  5 passed (5)
#      Tests  160 passed (160)
```

False-green check: reverting just `src/regular/jsonrepair.ts` + `src/streaming/core.ts` causes the 2 new-test rows to fail with the original error, confirming the tests actually exercise the new code paths in both implementations.

## Notes

- Scope is object-root only; array-root analogues (e.g. `[1,2]],3]`) are out of scope since the reported issue is object-only and can be handled separately if desired. A comment in the recovery block records this.
- My issue comment said I would leave the streaming path for a follow-up, but since tests run against both implementations and recent PRs (e.g. #140) refactor both, I fixed it in the same change for consistency. Happy to split if you'd prefer to review them separately.
- No CHANGELOG.md entry added — recent entries appear to be added by the `standard-version` release script.