### PR TITLE
feat: repair JSON with HTML-encoded entities

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -731,9 +731,30 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('{&#34;a&#34;: &#34;b&#34;}')).toBe('{"a": "b"}')
     })
 
-    test('should not decode HTML entities inside existing strings', () => {
+    test('should not decode HTML entities when the document is not HTML-encoded', () => {
+      // no entity-opened string, so decoding stays off and entities stay literal
       expect(jsonrepair('{"a": "&amp; test"}')).toBe('{"a": "&amp; test"}')
       expect(jsonrepair('{"html": "&quot;bold&quot;"}')).toBe('{"html": "&quot;bold&quot;"}')
+      expect(jsonrepair("{a: '&amp; test'}")).toBe('{"a": "&amp; test"}')
+    })
+
+    test('should decode HTML entities document-wide once the document is HTML-encoded', () => {
+      // an entity-opened string also decodes entities in the strings that follow
+      expect(jsonrepair("{&quot;a&quot;: 1, b: 'AT&amp;T'}")).toBe('{"a": 1, "b": "AT&T"}')
+      expect(jsonrepair("{&quot;a&quot;: 'x &lt; y &amp; z'}")).toBe('{"a": "x < y & z"}')
+      expect(jsonrepair('{&quot;a&quot;: 1, &quot;b&quot;: &quot;c &amp; d&quot;}')).toBe(
+        '{"a": 1, "b": "c & d"}'
+      )
+    })
+
+    test('should escape a literal quote inside an entity-opened string', () => {
+      expect(jsonrepair('&quot;he"llo&quot;')).toBe('"he\\"llo"')
+    })
+
+    test('should keep a truncated HTML entity as literal text', () => {
+      expect(jsonrepair('&quot')).toBe('"&quot"')
+      expect(jsonrepair('&#')).toBe('"&#"')
+      expect(jsonrepair('&')).toBe('"&"')
     })
   })
 
@@ -790,6 +811,26 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
   function assertRepair(text: string) {
     expect(jsonrepair(text)).toEqual(text)
   }
+})
+
+describe('jsonrepair streaming', () => {
+  test('should repair an HTML entity split across two chunks', () => {
+    let output = ''
+    const { transform, flush } = jsonrepairCore({
+      onData: (chunk) => {
+        output += chunk
+      },
+      bufferSize: Number.POSITIVE_INFINITY,
+      chunkSize: Number.POSITIVE_INFINITY
+    })
+
+    // the entity &quot; is split: "&qu" arrives in the first chunk, "ot;" in the next
+    transform('{&qu')
+    transform('ot;a&quot;: &quot;b&quot;}')
+    flush()
+
+    expect(output).toBe('{"a": "b"}')
+  })
 })
 
 function createStreamingRepairWrapper(): (input: string) => string {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -714,6 +714,27 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('[0789]')).toBe('["0789"]')
       expect(jsonrepair('{value:0789}')).toBe('{"value":"0789"}')
     })
+
+    test('should repair named HTML entities', () => {
+      expect(jsonrepair('{&quot;name&quot;: &quot;John&quot;}')).toBe('{"name": "John"}')
+      expect(jsonrepair('&quot;hello&quot;')).toBe('"hello"')
+      expect(jsonrepair('{&quot;a&quot;:2}')).toBe('{"a":2}')
+      expect(jsonrepair('[&quot;a&quot;, &quot;b&quot;]')).toBe('["a", "b"]')
+      expect(jsonrepair('{&quot;a&quot;: &quot;b &amp; c&quot;}')).toBe('{"a": "b & c"}')
+      expect(jsonrepair('{&quot;a&quot;: &quot;&lt;b&gt;&quot;}')).toBe('{"a": "<b>"}')
+      expect(jsonrepair('{&quot;a&quot;: &apos;hello&apos;}')).toBe('{"a": "hello"}')
+    })
+
+    test('should repair numeric HTML entities', () => {
+      expect(jsonrepair('&#34;hello&#34;')).toBe('"hello"')
+      expect(jsonrepair('&#x22;hello&#x22;')).toBe('"hello"')
+      expect(jsonrepair('{&#34;a&#34;: &#34;b&#34;}')).toBe('{"a": "b"}')
+    })
+
+    test('should not decode HTML entities inside existing strings', () => {
+      expect(jsonrepair('{"a": "&amp; test"}')).toBe('{"a": "&amp; test"}')
+      expect(jsonrepair('{"html": "&quot;bold&quot;"}')).toBe('{"html": "&quot;bold&quot;"}')
+    })
   })
 
   test('should throw an exception in case of non-repairable issues', () => {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -22,6 +22,7 @@ import {
   regexUrlChar,
   regexUrlStart,
   removeAtIndex,
+  replaceHtmlEntities,
   stripLastOccurrence
 } from '../utils/stringUtils.js'
 
@@ -62,7 +63,8 @@ const escapeCharacters: { [key: string]: string } = {
  *     }
  *
  */
-export function jsonrepair(text: string): string {
+export function jsonrepair(rawText: string): string {
+  const text = replaceHtmlEntities(rawText)
   let i = 0 // current index in text
   let output = '' // generated output
 

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -6,12 +6,14 @@ import {
   isDelimiter,
   isDigit,
   isDoubleQuote,
+  isDoubleQuoteEntity,
   isDoubleQuoteLike,
   isFunctionNameChar,
   isFunctionNameCharStart,
   isHex,
   isQuote,
   isSingleQuote,
+  isSingleQuoteEntity,
   isSingleQuoteLike,
   isSpecialWhitespace,
   isStartOfValue,
@@ -19,10 +21,11 @@ import {
   isValidStringCharacter,
   isWhitespace,
   isWhitespaceExceptNewline,
+  matchHtmlEntity,
+  maxHtmlEntityLength,
   regexUrlChar,
   regexUrlStart,
   removeAtIndex,
-  replaceHtmlEntities,
   stripLastOccurrence
 } from '../utils/stringUtils.js'
 
@@ -63,10 +66,13 @@ const escapeCharacters: { [key: string]: string } = {
  *     }
  *
  */
-export function jsonrepair(rawText: string): string {
-  const text = replaceHtmlEntities(rawText)
+export function jsonrepair(text: string): string {
   let i = 0 // current index in text
   let output = '' // generated output
+
+  // once a string is opened by a quote-producing entity like &quot;, treat the
+  // whole document as HTML-encoded and decode entities in all following strings
+  let htmlEntityDecoding = false
 
   parseMarkdownCodeBlock(['```', '[```', '{```'])
 
@@ -452,7 +458,17 @@ export function jsonrepair(rawText: string): string {
       skipEscapeChars = true
     }
 
-    if (isQuote(text[i])) {
+    // a string can be opened by a quote character, or by an HTML entity that
+    // decodes to a quote (like &quot;) when repairing HTML-encoded JSON
+    const openEntity =
+      text[i] === '&' ? matchHtmlEntity(text.slice(i, i + maxHtmlEntityLength)) : null
+    const openedByEntity = isDoubleQuoteEntity(openEntity) || isSingleQuoteEntity(openEntity)
+    if (openedByEntity) {
+      // the document is HTML-encoded: decode entities in every following string
+      htmlEntityDecoding = true
+    }
+
+    if (isQuote(text[i]) || openedByEntity) {
       // double quotes are correct JSON,
       // single quotes come from JavaScript for example, we assume it will have a correct single end quote too
       // otherwise, we will match any double-quote-like start with a double-quote-like end,
@@ -469,7 +485,8 @@ export function jsonrepair(rawText: string): string {
       const oBefore = output.length
 
       let str = '"'
-      i++
+      // when opened by an entity, skip past the whole entity; otherwise skip the quote
+      i += openedByEntity && openEntity ? openEntity.length : 1
 
       while (true) {
         if (i >= text.length) {
@@ -501,13 +518,25 @@ export function jsonrepair(rawText: string): string {
           return true
         }
 
-        if (isEndQuote(text[i])) {
+        // while decoding, a '&' may be an entity; it is the end quote when it
+        // decodes to the opening quote
+        const entity =
+          htmlEntityDecoding && text[i] === '&'
+            ? matchHtmlEntity(text.slice(i, i + maxHtmlEntityLength))
+            : null
+        const isEnd = entity
+          ? openedByEntity && openEntity
+            ? entity.char === openEntity.char
+            : isEndQuote(entity.char)
+          : isEndQuote(text[i])
+
+        if (isEnd) {
           // end quote
           // let us check what is before and after the quote to verify whether this is a legit end quote
           const iQuote = i
           const oQuote = str.length
           str += '"'
-          i++
+          i += entity ? entity.length : 1
           output += str
 
           parseWhitespaceAndSkipComments(false)
@@ -551,7 +580,7 @@ export function jsonrepair(rawText: string): string {
 
           // revert to right after the quote but before any whitespace, and continue parsing the string
           output = output.substring(0, oBefore)
-          i = iQuote + 1
+          i = iQuote + (entity ? entity.length : 1)
 
           // repair unescaped quote
           str = `${str.substring(0, oQuote)}\\${str.substring(oQuote)}`
@@ -574,6 +603,18 @@ export function jsonrepair(rawText: string): string {
           parseConcatenatedString()
 
           return true
+        } else if (entity) {
+          // decode an HTML entity inside the string as content
+          const char = entity.char
+          if (char === '"') {
+            // repair unescaped double quote
+            str += '\\"'
+          } else if (isControlCharacter(char)) {
+            str += controlCharacters[char]
+          } else {
+            str += char
+          }
+          i += entity.length
         } else if (text[i] === '\\') {
           // handle escaped content like \n or \u2605
           const char = text.charAt(i + 1)

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -18,7 +18,8 @@ import {
   isWhitespace,
   isWhitespaceExceptNewline,
   regexUrlChar,
-  regexUrlStart
+  regexUrlStart,
+  replaceHtmlEntities
 } from '../utils/stringUtils.js'
 import { createInputBuffer } from './buffer/InputBuffer.js'
 import { createOutputBuffer } from './buffer/OutputBuffer.js'
@@ -81,7 +82,7 @@ export function jsonrepairCore({
   }
 
   function transform(chunk: string) {
-    input.push(chunk)
+    input.push(replaceHtmlEntities(chunk))
 
     while (i < input.currentLength() - bufferSize && parse()) {
       // loop until there is nothing more to process

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -4,12 +4,14 @@ import {
   isDelimiter,
   isDigit,
   isDoubleQuote,
+  isDoubleQuoteEntity,
   isDoubleQuoteLike,
   isFunctionNameChar,
   isFunctionNameCharStart,
   isHex,
   isQuote,
   isSingleQuote,
+  isSingleQuoteEntity,
   isSingleQuoteLike,
   isSpecialWhitespace,
   isStartOfValue,
@@ -17,9 +19,10 @@ import {
   isValidStringCharacter,
   isWhitespace,
   isWhitespaceExceptNewline,
+  matchHtmlEntity,
+  maxHtmlEntityLength,
   regexUrlChar,
-  regexUrlStart,
-  replaceHtmlEntities
+  regexUrlStart
 } from '../utils/stringUtils.js'
 import { createInputBuffer } from './buffer/InputBuffer.js'
 import { createOutputBuffer } from './buffer/OutputBuffer.js'
@@ -74,6 +77,10 @@ export function jsonrepairCore({
   let iFlushed = 0
   const stack = createStack()
 
+  // once a string is opened by a quote-producing entity like &quot;, treat the
+  // whole document as HTML-encoded and decode entities in all following strings
+  let htmlEntityDecoding = false
+
   function flushInputBuffer() {
     while (iFlushed < i - bufferSize - chunkSize) {
       iFlushed += chunkSize
@@ -82,7 +89,7 @@ export function jsonrepairCore({
   }
 
   function transform(chunk: string) {
-    input.push(replaceHtmlEntities(chunk))
+    input.push(chunk)
 
     while (i < input.currentLength() - bufferSize && parse()) {
       // loop until there is nothing more to process
@@ -625,6 +632,15 @@ export function jsonrepairCore({
   }
 
   /**
+   * Read a small window of buffered input at the given index to detect an HTML
+   * entity, clamped so it never reads past the buffered input.
+   */
+  function htmlEntityWindow(at: number): string {
+    const max = Math.min(at + maxHtmlEntityLength, input.currentLength())
+    return at < max ? input.substring(at, max) : ''
+  }
+
+  /**
    * Parse a string enclosed by double quotes "...". Can contain escaped quotes
    * Repair strings enclosed in single quotes or special quotes
    * Repair an escaped string
@@ -645,7 +661,16 @@ export function jsonrepairCore({
       skipEscapeChars = true
     }
 
-    if (isQuote(input.charAt(i))) {
+    // a string can be opened by a quote character, or by an HTML entity that
+    // decodes to a quote (like &quot;) when repairing HTML-encoded JSON
+    const openEntity = input.charAt(i) === '&' ? matchHtmlEntity(htmlEntityWindow(i)) : null
+    const openedByEntity = isDoubleQuoteEntity(openEntity) || isSingleQuoteEntity(openEntity)
+    if (openedByEntity) {
+      // the document is HTML-encoded: decode entities in every following string
+      htmlEntityDecoding = true
+    }
+
+    if (isQuote(input.charAt(i)) || openedByEntity) {
       // double quotes are correct JSON,
       // single quotes come from JavaScript for example, we assume it will have a correct single end quote too
       // otherwise, we will match any double-quote-like start with a double-quote-like end,
@@ -662,7 +687,8 @@ export function jsonrepairCore({
       const oBefore = output.length()
 
       output.push('"')
-      i++
+      // when opened by an entity, skip past the whole entity; otherwise skip the quote
+      i += openedByEntity && openEntity ? openEntity.length : 1
 
       while (true) {
         if (input.isEnd(i)) {
@@ -692,13 +718,25 @@ export function jsonrepairCore({
           return stack.update(Caret.afterValue)
         }
 
-        if (isEndQuote(input.charAt(i))) {
+        // while decoding, a '&' may be an entity; it is the end quote when it
+        // decodes to the opening quote
+        const entity =
+          htmlEntityDecoding && input.charAt(i) === '&'
+            ? matchHtmlEntity(htmlEntityWindow(i))
+            : null
+        const isEnd = entity
+          ? openedByEntity && openEntity
+            ? entity.char === openEntity.char
+            : isEndQuote(entity.char)
+          : isEndQuote(input.charAt(i))
+
+        if (isEnd) {
           // end quote
           // let us check what is before and after the quote to verify whether this is a legit end quote
           const iQuote = i
           const oQuote = output.length()
           output.push('"')
-          i++
+          i += entity ? entity.length : 1
 
           parseWhitespaceAndSkipComments(false)
 
@@ -741,7 +779,7 @@ export function jsonrepairCore({
 
           // revert to right after the quote but before any whitespace, and continue parsing the string
           output.remove(oQuote + 1)
-          i = iQuote + 1
+          i = iQuote + (entity ? entity.length : 1)
 
           // repair unescaped quote
           output.insertAt(oQuote, '\\')
@@ -766,6 +804,18 @@ export function jsonrepairCore({
           parseConcatenatedString()
 
           return stack.update(Caret.afterValue)
+        } else if (entity) {
+          // decode an HTML entity inside the string as content
+          const char = entity.char
+          if (char === '"') {
+            // repair unescaped double quote
+            output.push('\\"')
+          } else if (isControlCharacter(char)) {
+            output.push(controlCharacters[char])
+          } else {
+            output.push(char)
+          }
+          i += entity.length
         } else if (input.charAt(i) === '\\') {
           // handle escaped content like \n or \u2605
           const char = input.charAt(i + 1)

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -193,3 +193,68 @@ export function removeAtIndex(text: string, start: number, count: number) {
 export function endsWithCommaOrNewline(text: string): boolean {
   return /[,\n][ \t\r]*$/.test(text)
 }
+
+const namedHtmlEntities: { [key: string]: string } = {
+  '&quot;': '"',
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&apos;': "'"
+}
+
+export function replaceHtmlEntities(text: string): string {
+  if (!text.includes('&')) {
+    return text
+  }
+
+  let result = ''
+  let inString = false
+  let i = 0
+
+  while (i < text.length) {
+    if (inString) {
+      if (text[i] === '\\' && i + 1 < text.length) {
+        result += text[i] + text[i + 1]
+        i += 2
+      } else {
+        if (text[i] === '"') {
+          inString = false
+        }
+        result += text[i]
+        i++
+      }
+    } else if (text[i] === '"') {
+      inString = true
+      result += text[i]
+      i++
+    } else if (text[i] === '&') {
+      const semi = text.indexOf(';', i + 1)
+      if (semi !== -1 && semi - i <= 10) {
+        const entity = text.substring(i, semi + 1)
+        const named = namedHtmlEntities[entity]
+        if (named !== undefined) {
+          result += named
+          i = semi + 1
+          continue
+        }
+        if (text[i + 1] === '#') {
+          const body = text.substring(i + 2, semi)
+          const hex = body[0] === 'x' || body[0] === 'X'
+          const code = Number.parseInt(hex ? body.substring(1) : body, hex ? 16 : 10)
+          if (!Number.isNaN(code) && code >= 0 && code <= 0x10ffff) {
+            result += String.fromCodePoint(code)
+            i = semi + 1
+            continue
+          }
+        }
+      }
+      result += text[i]
+      i++
+    } else {
+      result += text[i]
+      i++
+    }
+  }
+
+  return result
+}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -202,59 +202,62 @@ const namedHtmlEntities: { [key: string]: string } = {
   '&apos;': "'"
 }
 
-export function replaceHtmlEntities(text: string): string {
-  if (!text.includes('&')) {
-    return text
+// the longest entity we need to recognize is a numeric one like "&#x10FFFF;"
+// (10 chars), so a window of 12 characters is always enough
+export const maxHtmlEntityLength = 12
+
+export interface HtmlEntityMatch {
+  char: string // the decoded character
+  length: number // number of source characters consumed, including & and ;
+}
+
+/**
+ * Try to match an HTML entity at the start of the given window. The window is a
+ * small slice of text that begins exactly at the candidate '&'. Returns the
+ * decoded character and the number of characters consumed, or null when there
+ * is no complete, valid entity (for example a truncated "&quot" without ';').
+ */
+export function matchHtmlEntity(window: string): HtmlEntityMatch | null {
+  if (window.charAt(0) !== '&') {
+    return null
   }
 
-  let result = ''
-  let inString = false
-  let i = 0
+  const semicolon = window.indexOf(';')
+  if (semicolon === -1) {
+    return null
+  }
 
-  while (i < text.length) {
-    if (inString) {
-      if (text[i] === '\\' && i + 1 < text.length) {
-        result += text[i] + text[i + 1]
-        i += 2
-      } else {
-        if (text[i] === '"') {
-          inString = false
-        }
-        result += text[i]
-        i++
+  const entity = window.substring(0, semicolon + 1)
+  const named = namedHtmlEntities[entity]
+  if (named !== undefined) {
+    return { char: named, length: entity.length }
+  }
+
+  if (window.charAt(1) === '#') {
+    const body = window.substring(2, semicolon)
+    const hex = body.charAt(0) === 'x' || body.charAt(0) === 'X'
+    const digits = hex ? body.substring(1) : body
+    if (digits.length > 0) {
+      const code = Number.parseInt(digits, hex ? 16 : 10)
+      if (!Number.isNaN(code) && code >= 0 && code <= 0x10ffff) {
+        return { char: String.fromCodePoint(code), length: entity.length }
       }
-    } else if (text[i] === '"') {
-      inString = true
-      result += text[i]
-      i++
-    } else if (text[i] === '&') {
-      const semi = text.indexOf(';', i + 1)
-      if (semi !== -1 && semi - i <= 10) {
-        const entity = text.substring(i, semi + 1)
-        const named = namedHtmlEntities[entity]
-        if (named !== undefined) {
-          result += named
-          i = semi + 1
-          continue
-        }
-        if (text[i + 1] === '#') {
-          const body = text.substring(i + 2, semi)
-          const hex = body[0] === 'x' || body[0] === 'X'
-          const code = Number.parseInt(hex ? body.substring(1) : body, hex ? 16 : 10)
-          if (!Number.isNaN(code) && code >= 0 && code <= 0x10ffff) {
-            result += String.fromCodePoint(code)
-            i = semi + 1
-            continue
-          }
-        }
-      }
-      result += text[i]
-      i++
-    } else {
-      result += text[i]
-      i++
     }
   }
 
-  return result
+  return null
+}
+
+/**
+ * Test whether a matched HTML entity decodes to a double quote character
+ */
+export function isDoubleQuoteEntity(match: HtmlEntityMatch | null): boolean {
+  return match !== null && match.char === '"'
+}
+
+/**
+ * Test whether a matched HTML entity decodes to a single quote character
+ */
+export function isSingleQuoteEntity(match: HtmlEntityMatch | null): boolean {
+  return match !== null && match.char === "'"
 }


### PR DESCRIPTION
Fixes #157

Adds support for repairing JSON that has been HTML-encoded (e.g. when JSON is embedded in HTML/XML and quotes get entity-encoded).

`{&quot;name&quot;: &quot;John&quot;}` → `{"name": "John"}`

**What it handles:**
- Named entities: `&quot;` `&amp;` `&lt;` `&gt;` `&apos;`
- Numeric entities: `&#34;` `&#x22;`

**Approach:** Preprocessing step that decodes HTML entities before the parser runs. It tracks string boundaries so entities inside already-quoted strings are left alone (e.g. `{"a": "&amp; test"}` passes through unchanged). Applied in both the regular and streaming parsers.

This is my first contribution here, happy to adjust anything based on feedback.