### PR TITLE
fix: unescaped quotes before special characters

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -326,7 +326,9 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
 
       // multiple sets of parentheses, both nested and non-nested, with an unescaped quote among them
       expect(jsonrepair('"a (b) ((c") d)"')).toBe('"a (b) ((c\\") d)"')
-      expect(jsonrepair('"He (52) is six feet ((72")) tall"')).toBe('"He (52) is six feet ((72\\")) tall"')
+      expect(jsonrepair('"He (52) is six feet ((72")) tall"')).toBe(
+        '"He (52) is six feet ((72\\")) tall"'
+      )
 
       // unescaped quote before a closing ] or } (something other than parentheses)
       expect(jsonrepair('"the list [1, 2"] more"')).toBe('"the list [1, 2\\"] more"')

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -320,6 +320,22 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('"The TV is 72""')).toBe('"The TV is 72\\""')
     })
 
+    test('should escape unescaped double quotes in the middle of a string', () => {
+      // unescaped quote followed by a closing parenthesis in the middle of the string
+      expect(jsonrepair('"He is six feet (72") tall"')).toBe('"He is six feet (72\\") tall"')
+
+      // multiple sets of parentheses, both nested and non-nested, with an unescaped quote among them
+      expect(jsonrepair('"a (b) ((c") d)"')).toBe('"a (b) ((c\\") d)"')
+      expect(jsonrepair('"He (52) is six feet ((72")) tall"')).toBe('"He (52) is six feet ((72\\")) tall"')
+
+      // unescaped quote before a closing ] or } (something other than parentheses)
+      expect(jsonrepair('"the list [1, 2"] more"')).toBe('"the list [1, 2\\"] more"')
+      expect(jsonrepair('"the set {a, b"} more"')).toBe('"the set {a, b\\"} more"')
+
+      // only a closing parenthesis and no opening one: the quote is the real end of the string
+      expect(jsonrepair('["foo)" 2]')).toBe('["foo)", 2]')
+    })
+
     test('should replace special white space characters', () => {
       expect(jsonrepair('{"a":\u00a0"foo\u00a0bar"}')).toBe('{"a": "foo\u00a0bar"}')
       expect(jsonrepair('{"a":\u180e"foo"}')).toBe('{"a": "foo"}')

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -316,6 +316,8 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('["a" 2]')).toBe('["a", 2]')
       expect(jsonrepair('["a" 2')).toBe('["a", 2]')
       expect(jsonrepair('["," 2')).toBe('[",", 2]')
+      expect(jsonrepair('{ "height": "(5\'3")" }')).toBe('{ "height": "(5\'3\\")" }')
+      expect(jsonrepair('"The TV is 72""')).toBe('"The TV is 72\\""')
     })
 
     test('should replace special white space characters', () => {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -469,6 +469,8 @@ export function jsonrepair(text: string): string {
       let str = '"'
       i++
       let openParenCount = 0
+      let openBracketCount = 0
+      let openBraceCount = 0
 
       while (true) {
         if (i >= text.length) {
@@ -521,7 +523,10 @@ export function jsonrepair(text: string): string {
           if (
             stopAtDelimiter ||
             i >= text.length ||
-            (isDelimiter(text[i]) && !(text[i] === ')' && openParenCount > 0)) ||
+            (isDelimiter(text[i]) &&
+              !(text[i] === ')' && openParenCount > 0) &&
+              !(text[i] === ']' && openBracketCount > 0) &&
+              !(text[i] === '}' && openBraceCount > 0)) ||
             (isQuote(text[i]) && !nextQuoteIsEndQuote) ||
             isDigit(text[i])
           ) {
@@ -631,6 +636,10 @@ export function jsonrepair(text: string): string {
             str += char
             if (char === '(') openParenCount++
             else if (char === ')') openParenCount--
+            else if (char === '[') openBracketCount++
+            else if (char === ']') openBracketCount--
+            else if (char === '{') openBraceCount++
+            else if (char === '}') openBraceCount--
             i++
           }
         }

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -1,5 +1,6 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
 import {
+  countOccurrences,
   endsWithCommaOrNewline,
   insertBeforeLastWhitespace,
   isControlCharacter,
@@ -468,9 +469,6 @@ export function jsonrepair(text: string): string {
 
       let str = '"'
       i++
-      let openParenCount = 0
-      let openBracketCount = 0
-      let openBraceCount = 0
 
       while (true) {
         if (i >= text.length) {
@@ -513,21 +511,16 @@ export function jsonrepair(text: string): string {
 
           parseWhitespaceAndSkipComments(false)
 
-          // when the next char is a quote, peek past it: if nothing meaningful follows,
-          // that quote is the true end and this one is embedded (e.g. `"The TV is 72""`)
-          let jPeek = i + 1
-          while (jPeek < text.length && isWhitespace(text, jPeek)) jPeek++
-          const nextQuoteIsEndQuote =
-            isQuote(text[i]) && (jPeek >= text.length || isDelimiter(text[jPeek]))
-
           if (
             stopAtDelimiter ||
             i >= text.length ||
             (isDelimiter(text[i]) &&
-              !(text[i] === ')' && openParenCount > 0) &&
-              !(text[i] === ']' && openBracketCount > 0) &&
-              !(text[i] === '}' && openBraceCount > 0)) ||
-            (isQuote(text[i]) && !nextQuoteIsEndQuote) ||
+              // only count the brackets inside the string when actually needed,
+              // i.e. when the quote is directly followed by a closing bracket
+              !(text[i] === ')' && countOccurrences(str, '(') - countOccurrences(str, ')') > 0) &&
+              !(text[i] === ']' && countOccurrences(str, '[') - countOccurrences(str, ']') > 0) &&
+              !(text[i] === '}' && countOccurrences(str, '{') - countOccurrences(str, '}') > 0)) ||
+            (isQuote(text[i]) && !nextQuoteIsEndQuote(i)) ||
             isDigit(text[i])
           ) {
             // The quote is followed by the end of the text, a delimiter,
@@ -634,12 +627,6 @@ export function jsonrepair(text: string): string {
               throwInvalidCharacter(char)
             }
             str += char
-            if (char === '(') openParenCount++
-            else if (char === ')') openParenCount--
-            else if (char === '[') openBracketCount++
-            else if (char === ']') openBracketCount--
-            else if (char === '{') openBraceCount++
-            else if (char === '}') openBraceCount--
             i++
           }
         }
@@ -885,6 +872,17 @@ export function jsonrepair(text: string): string {
     }
 
     return prev
+  }
+
+  function nextQuoteIsEndQuote(index: number): boolean {
+    // precondition: text[index] is a quote. Peek past it: if nothing meaningful
+    // follows, that quote is the true end and this one is embedded (e.g. `"The TV is 72""`)
+    let next = index + 1
+    while (next < text.length && isWhitespace(text, next)) {
+      next++
+    }
+
+    return next >= text.length || isDelimiter(text[next])
   }
 
   function atEndOfNumber() {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -1,6 +1,5 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
 import {
-  countOccurrences,
   endsWithCommaOrNewline,
   insertBeforeLastWhitespace,
   isControlCharacter,
@@ -11,6 +10,7 @@ import {
   isFunctionNameChar,
   isFunctionNameCharStart,
   isHex,
+  isInsideUnclosedBracket,
   isQuote,
   isSingleQuote,
   isSingleQuoteLike,
@@ -517,9 +517,7 @@ export function jsonrepair(text: string): string {
             (isDelimiter(text[i]) &&
               // only count the brackets inside the string when actually needed,
               // i.e. when the quote is directly followed by a closing bracket
-              !(text[i] === ')' && countOccurrences(str, '(') - countOccurrences(str, ')') > 0) &&
-              !(text[i] === ']' && countOccurrences(str, '[') - countOccurrences(str, ']') > 0) &&
-              !(text[i] === '}' && countOccurrences(str, '{') - countOccurrences(str, '}') > 0)) ||
+              !isInsideUnclosedBracket(str, text[i])) ||
             (isQuote(text[i]) && !nextQuoteIsEndQuote(i)) ||
             isDigit(text[i])
           ) {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -468,6 +468,7 @@ export function jsonrepair(text: string): string {
 
       let str = '"'
       i++
+      let openParenCount = 0
 
       while (true) {
         if (i >= text.length) {
@@ -510,11 +511,18 @@ export function jsonrepair(text: string): string {
 
           parseWhitespaceAndSkipComments(false)
 
+          // when the next char is a quote, peek past it: if nothing meaningful follows,
+          // that quote is the true end and this one is embedded (e.g. `"The TV is 72""`)
+          let jPeek = i + 1
+          while (jPeek < text.length && isWhitespace(text, jPeek)) jPeek++
+          const nextQuoteIsEndQuote =
+            isQuote(text[i]) && (jPeek >= text.length || isDelimiter(text[jPeek]))
+
           if (
             stopAtDelimiter ||
             i >= text.length ||
-            isDelimiter(text[i]) ||
-            isQuote(text[i]) ||
+            (isDelimiter(text[i]) && !(text[i] === ')' && openParenCount > 0)) ||
+            (isQuote(text[i]) && !nextQuoteIsEndQuote) ||
             isDigit(text[i])
           ) {
             // The quote is followed by the end of the text, a delimiter,
@@ -621,6 +629,8 @@ export function jsonrepair(text: string): string {
               throwInvalidCharacter(char)
             }
             str += char
+            if (char === '(') openParenCount++
+            else if (char === ')') openParenCount--
             i++
           }
         }

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -662,6 +662,7 @@ export function jsonrepairCore({
 
       output.push('"')
       i++
+      let openParenCount = 0
 
       while (true) {
         if (input.isEnd(i)) {
@@ -701,11 +702,18 @@ export function jsonrepairCore({
 
           parseWhitespaceAndSkipComments(false)
 
+          // when the next char is a quote, peek past it: if nothing meaningful follows,
+          // that quote is the true end and this one is embedded (e.g. `"The TV is 72""`)
+          let jPeek = i + 1
+          while (!input.isEnd(jPeek) && isWhitespace(input, jPeek)) jPeek++
+          const nextQuoteIsEndQuote =
+            isQuote(input.charAt(i)) && (input.isEnd(jPeek) || isDelimiter(input.charAt(jPeek)))
+
           if (
             stopAtDelimiter ||
             input.isEnd(i) ||
-            isDelimiter(input.charAt(i)) ||
-            isQuote(input.charAt(i)) ||
+            (isDelimiter(input.charAt(i)) && !(input.charAt(i) === ')' && openParenCount > 0)) ||
+            (isQuote(input.charAt(i)) && !nextQuoteIsEndQuote) ||
             isDigit(input.charAt(i))
           ) {
             // The quote is followed by the end of the text, a delimiter, or a next value
@@ -814,6 +822,8 @@ export function jsonrepairCore({
               throwInvalidCharacter(char)
             }
             output.push(char)
+            if (char === '(') openParenCount++
+            else if (char === ')') openParenCount--
             i++
           }
         }

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -1,5 +1,6 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
 import {
+  countOccurrences,
   isControlCharacter,
   isDelimiter,
   isDigit,
@@ -662,9 +663,6 @@ export function jsonrepairCore({
 
       output.push('"')
       i++
-      let openParenCount = 0
-      let openBracketCount = 0
-      let openBraceCount = 0
 
       while (true) {
         if (input.isEnd(i)) {
@@ -704,21 +702,31 @@ export function jsonrepairCore({
 
           parseWhitespaceAndSkipComments(false)
 
-          // when the next char is a quote, peek past it: if nothing meaningful follows,
-          // that quote is the true end and this one is embedded (e.g. `"The TV is 72""`)
-          let jPeek = i + 1
-          while (!input.isEnd(jPeek) && isWhitespace(input, jPeek)) jPeek++
-          const nextQuoteIsEndQuote =
-            isQuote(input.charAt(i)) && (input.isEnd(jPeek) || isDelimiter(input.charAt(jPeek)))
-
           if (
             stopAtDelimiter ||
             input.isEnd(i) ||
             (isDelimiter(input.charAt(i)) &&
-              !(input.charAt(i) === ')' && openParenCount > 0) &&
-              !(input.charAt(i) === ']' && openBracketCount > 0) &&
-              !(input.charAt(i) === '}' && openBraceCount > 0)) ||
-            (isQuote(input.charAt(i)) && !nextQuoteIsEndQuote) ||
+              // only count the brackets inside the string when actually needed,
+              // i.e. when the quote is directly followed by a closing bracket
+              !(
+                input.charAt(i) === ')' &&
+                countOccurrences(input.substring(iBefore, iQuote), '(') -
+                  countOccurrences(input.substring(iBefore, iQuote), ')') >
+                  0
+              ) &&
+              !(
+                input.charAt(i) === ']' &&
+                countOccurrences(input.substring(iBefore, iQuote), '[') -
+                  countOccurrences(input.substring(iBefore, iQuote), ']') >
+                  0
+              ) &&
+              !(
+                input.charAt(i) === '}' &&
+                countOccurrences(input.substring(iBefore, iQuote), '{') -
+                  countOccurrences(input.substring(iBefore, iQuote), '}') >
+                  0
+              )) ||
+            (isQuote(input.charAt(i)) && !nextQuoteIsEndQuote(i)) ||
             isDigit(input.charAt(i))
           ) {
             // The quote is followed by the end of the text, a delimiter, or a next value
@@ -827,12 +835,6 @@ export function jsonrepairCore({
               throwInvalidCharacter(char)
             }
             output.push(char)
-            if (char === '(') openParenCount++
-            else if (char === ')') openParenCount--
-            else if (char === '[') openBracketCount++
-            else if (char === ']') openBracketCount--
-            else if (char === '{') openBraceCount++
-            else if (char === '}') openBraceCount--
             i++
           }
         }
@@ -1025,6 +1027,17 @@ export function jsonrepairCore({
     }
 
     return prev
+  }
+
+  function nextQuoteIsEndQuote(index: number): boolean {
+    // precondition: input.charAt(index) is a quote. Peek past it: if nothing meaningful
+    // follows, that quote is the true end and this one is embedded (e.g. `"The TV is 72""`)
+    let next = index + 1
+    while (!input.isEnd(next) && isWhitespace(input, next)) {
+      next++
+    }
+
+    return input.isEnd(next) || isDelimiter(input.charAt(next))
   }
 
   function atEndOfNumber() {

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -663,6 +663,8 @@ export function jsonrepairCore({
       output.push('"')
       i++
       let openParenCount = 0
+      let openBracketCount = 0
+      let openBraceCount = 0
 
       while (true) {
         if (input.isEnd(i)) {
@@ -712,7 +714,10 @@ export function jsonrepairCore({
           if (
             stopAtDelimiter ||
             input.isEnd(i) ||
-            (isDelimiter(input.charAt(i)) && !(input.charAt(i) === ')' && openParenCount > 0)) ||
+            (isDelimiter(input.charAt(i)) &&
+              !(input.charAt(i) === ')' && openParenCount > 0) &&
+              !(input.charAt(i) === ']' && openBracketCount > 0) &&
+              !(input.charAt(i) === '}' && openBraceCount > 0)) ||
             (isQuote(input.charAt(i)) && !nextQuoteIsEndQuote) ||
             isDigit(input.charAt(i))
           ) {
@@ -824,6 +829,10 @@ export function jsonrepairCore({
             output.push(char)
             if (char === '(') openParenCount++
             else if (char === ')') openParenCount--
+            else if (char === '[') openBracketCount++
+            else if (char === ']') openBracketCount--
+            else if (char === '{') openBraceCount++
+            else if (char === '}') openBraceCount--
             i++
           }
         }

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -1,6 +1,5 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
 import {
-  countOccurrences,
   isControlCharacter,
   isDelimiter,
   isDigit,
@@ -9,6 +8,7 @@ import {
   isFunctionNameChar,
   isFunctionNameCharStart,
   isHex,
+  isInsideUnclosedBracket,
   isQuote,
   isSingleQuote,
   isSingleQuoteLike,
@@ -708,24 +708,7 @@ export function jsonrepairCore({
             (isDelimiter(input.charAt(i)) &&
               // only count the brackets inside the string when actually needed,
               // i.e. when the quote is directly followed by a closing bracket
-              !(
-                input.charAt(i) === ')' &&
-                countOccurrences(input.substring(iBefore, iQuote), '(') -
-                  countOccurrences(input.substring(iBefore, iQuote), ')') >
-                  0
-              ) &&
-              !(
-                input.charAt(i) === ']' &&
-                countOccurrences(input.substring(iBefore, iQuote), '[') -
-                  countOccurrences(input.substring(iBefore, iQuote), ']') >
-                  0
-              ) &&
-              !(
-                input.charAt(i) === '}' &&
-                countOccurrences(input.substring(iBefore, iQuote), '{') -
-                  countOccurrences(input.substring(iBefore, iQuote), '}') >
-                  0
-              )) ||
+              !isInsideUnclosedBracket(input.substring(iBefore, iQuote), input.charAt(i))) ||
             (isQuote(input.charAt(i)) && !nextQuoteIsEndQuote(i)) ||
             isDigit(input.charAt(i))
           ) {

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -193,3 +193,16 @@ export function removeAtIndex(text: string, start: number, count: number) {
 export function endsWithCommaOrNewline(text: string): boolean {
   return /[,\n][ \t\r]*$/.test(text)
 }
+
+/**
+ * Count the number of occurrences of a single character in a string
+ */
+export function countOccurrences(text: string, char: string): number {
+  let count = 0
+  for (let i = 0; i < text.length; i++) {
+    if (text.charAt(i) === char) {
+      count++
+    }
+  }
+  return count
+}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -206,3 +206,25 @@ export function countOccurrences(text: string, char: string): number {
   }
   return count
 }
+
+/**
+ * Test whether `closeChar` is a closing bracket and `text` still contains an
+ * unmatched opening bracket of the same kind. This indicates that the end of
+ * `text` is located inside the brackets, for example the quote in
+ * `"a (b") c"` is followed by `)` while `(` is still unclosed.
+ *
+ * Note that the (potentially expensive) counting is only performed when
+ * `closeChar` actually is a closing bracket.
+ */
+export function isInsideUnclosedBracket(text: string, closeChar: string): boolean {
+  switch (closeChar) {
+    case ')':
+      return countOccurrences(text, '(') > countOccurrences(text, ')')
+    case ']':
+      return countOccurrences(text, '[') > countOccurrences(text, ']')
+    case '}':
+      return countOccurrences(text, '{') > countOccurrences(text, '}')
+    default:
+      return false
+  }
+}


### PR DESCRIPTION
Fixes #144 

Repairs JSON in instances where an unescaped double quote is right before the closing double quote or bracket.

`{ "height": "53"" }` → `{ "height": "53\"" }`

`{ "height": "(5'3")" }` → `{ "height": "(5'3\")" }`

Initially a double quote was counted as the end quote if the following character was a delimiter, including close brackets ( ), ], } ).  I implemented tracking of the open and close brackets in a string so that a close bracket that closes an open bracket will not indicate that the preceding double quote is an end quote.

For the case of an unescaped double quote immediately following an unescaped double quote, I added a part that looks past the second double quote and counts it as the true end quote if it is followed by a delimiter or the end of input. Otherwise, the first double quote is counted as the end quote and the second is counted as the starting quote of a new string.

Any feedback is appreciated!