### PR TITLE
Fix: improve repairing of numbers

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -564,7 +564,15 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('{greeting: hello world!}')).toBe('{"greeting": "hello world!"}')
     })
 
-    test('should turn invalid numbers into strings', () => {
+    test('should repair invalid numbers', () => {
+      expect(jsonrepair('2.')).toBe('2.0')
+      expect(jsonrepair('.3')).toBe('0.3')
+      expect(jsonrepair('-.3')).toBe('-0.3')
+      expect(jsonrepair('-05')).toBe('-05')
+      expect(jsonrepair('-')).toBe('-0')
+    })
+
+    test('should turn invalid unrepairable numbers into strings', () => {
       expect(jsonrepair('ES2020')).toBe('"ES2020"')
       expect(jsonrepair('0.0.1')).toBe('"0.0.1"')
       expect(jsonrepair('746de9ad-d4ff-4c66-97d7-00a92ad46967')).toBe(
@@ -574,6 +582,16 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('[0.0.1,2]')).toBe('["0.0.1",2]') // test delimiter for numerics
       expect(jsonrepair('[2 0.0.1 2]')).toBe('[2, "0.0.1 2"]') // note: currently spaces delimit numbers, but don't delimit unquoted strings
       expect(jsonrepair('2e3.4')).toBe('"2e3.4"')
+      expect(jsonrepair('00.')).toBe('"00."')
+
+      expect(jsonrepair('e')).toBe('"e"')
+      expect(jsonrepair('[e],')).toBe('["e"]')
+      expect(jsonrepair('[e5],')).toBe('["e5"]')
+      expect(jsonrepair('[-e5],')).toBe('["-e5"]')
+      expect(jsonrepair('{"k": e},')).toBe('{"k": "e"}')
+      expect(jsonrepair('{"n": 05}')).toBe('{"n": "05"}')
+      expect(jsonrepair('[05e]')).toBe('["05e"]')
+      expect(jsonrepair('.')).toBe('"."')
     })
 
     test('should repair regular expressions', () => {
@@ -643,7 +661,7 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       )
     })
 
-    test('should repair numbers at the end', () => {
+    test('should repair truncated numbers', () => {
       expect(jsonrepair('{"a":2.')).toBe('{"a":2.0}')
       expect(jsonrepair('{"a":2e')).toBe('{"a":2e0}')
       expect(jsonrepair('{"a":2e-')).toBe('{"a":2e-0}')
@@ -706,7 +724,7 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('a,b')).toBe('[\n"a","b"\n]')
     })
 
-    test('should repair a number with leading zero', () => {
+    test('should repair a number with leading zeros', () => {
       expect(jsonrepair('0789')).toBe('"0789"')
       expect(jsonrepair('000789')).toBe('"000789"')
       expect(jsonrepair('001.2')).toBe('"001.2"')

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -178,9 +178,11 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('{"foo')).toBe('{"foo":null}')
       expect(jsonrepair('{')).toBe('{}')
       expect(jsonrepair('2.')).toBe('2.0')
+      expect(jsonrepair('[2.]')).toBe('[2.0]')
       expect(jsonrepair('2e')).toBe('2e0')
       expect(jsonrepair('2e+')).toBe('2e+0')
       expect(jsonrepair('2e-')).toBe('2e-0')
+      expect(jsonrepair('[2e+]')).toBe('[2e+0]')
       expect(jsonrepair('{"foo":"bar\\u20')).toBe('{"foo":"bar"}')
       expect(jsonrepair('"\\u')).toBe('""')
       expect(jsonrepair('"\\u2')).toBe('""')
@@ -568,7 +570,6 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('2.')).toBe('2.0')
       expect(jsonrepair('.3')).toBe('0.3')
       expect(jsonrepair('-.3')).toBe('-0.3')
-      expect(jsonrepair('-05')).toBe('-05')
       expect(jsonrepair('-')).toBe('-0')
     })
 
@@ -583,6 +584,7 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('[2 0.0.1 2]')).toBe('[2, "0.0.1 2"]') // note: currently spaces delimit numbers, but don't delimit unquoted strings
       expect(jsonrepair('2e3.4')).toBe('"2e3.4"')
       expect(jsonrepair('00.')).toBe('"00."')
+      expect(jsonrepair('-05')).toBe('"-05"')
 
       expect(jsonrepair('e')).toBe('"e"')
       expect(jsonrepair('[e],')).toBe('["e"]')
@@ -591,7 +593,7 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('{"k": e},')).toBe('{"k": "e"}')
       expect(jsonrepair('{"n": 05}')).toBe('{"n": "05"}')
       expect(jsonrepair('[05e]')).toBe('["05e"]')
-      expect(jsonrepair('.')).toBe('"."')
+      expect(jsonrepair('.')).toBe('0.0')
     })
 
     test('should repair regular expressions', () => {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -1,4 +1,5 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
+import { repairNumber } from '../utils/numberUtils.js'
 import {
   endsWithCommaOrNewline,
   insertBeforeLastWhitespace,
@@ -670,69 +671,37 @@ export function jsonrepair(text: string): string {
     const start = i
     if (text[i] === '-') {
       i++
-      if (atEndOfNumber()) {
-        repairNumberEndingWithNumericSymbol(start)
-        return true
-      }
-      if (!isDigit(text[i])) {
-        i = start
-        return false
-      }
     }
 
-    // Note that in JSON leading zeros like "00789" are not allowed.
-    // We will allow all leading zeros here though and at the end of parseNumber
-    // check against trailing zeros and repair that if needed.
-    // Leading zeros can have meaning, so we should not clear them.
     while (isDigit(text[i])) {
       i++
     }
 
-    if (text[i] === '.') {
+    if (text[i] === '.' && (i > start || isDigit(text[i + 1]))) {
       i++
-      if (atEndOfNumber()) {
-        repairNumberEndingWithNumericSymbol(start)
-        return true
-      }
-      if (!isDigit(text[i])) {
-        i = start
-        return false
-      }
       while (isDigit(text[i])) {
         i++
       }
-    }
-
-    if (text[i] === 'e' || text[i] === 'E') {
-      i++
-      if (text[i] === '-' || text[i] === '+') {
-        i++
-      }
-      if (atEndOfNumber()) {
-        repairNumberEndingWithNumericSymbol(start)
-        return true
-      }
-      if (!isDigit(text[i])) {
-        i = start
-        return false
-      }
-      while (isDigit(text[i])) {
-        i++
-      }
-    }
-
-    // if we're not at the end of the number by this point, allow this to be parsed as another type
-    if (!atEndOfNumber()) {
-      i = start
-      return false
     }
 
     if (i > start) {
-      // repair a number with leading zeros like "00789"
-      const num = text.slice(start, i)
-      const hasInvalidLeadingZero = /^0\d/.test(num)
+      if (text[i] === 'e' || text[i] === 'E') {
+        i++
+        if (text[i] === '-' || text[i] === '+') {
+          i++
+        }
+        while (isDigit(text[i])) {
+          i++
+        }
+      }
 
-      output += hasInvalidLeadingZero ? `"${num}"` : num
+      // if we're not at the end of the number by this point, allow this to be parsed as another type
+      if (!atEndOfNumber()) {
+        i = start
+        return false
+      }
+
+      output += repairNumber(text.slice(start, i))
       return true
     }
 
@@ -870,13 +839,6 @@ export function jsonrepair(text: string): string {
 
   function atEndOfNumber() {
     return i >= text.length || isDelimiter(text[i]) || isWhitespace(text, i)
-  }
-
-  function repairNumberEndingWithNumericSymbol(start: number) {
-    // repair numbers cut off at the end
-    // this will only be called when we end after a '.', '-', or 'e' and does not
-    // change the number more than it needs to make it valid JSON
-    output += `${text.slice(start, i)}0`
   }
 
   function throwInvalidCharacter(char: string) {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -1,5 +1,4 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
-import { repairNumber } from '../utils/numberUtils.js'
 import {
   endsWithCommaOrNewline,
   insertBeforeLastWhitespace,
@@ -669,28 +668,70 @@ export function jsonrepair(text: string): string {
    */
   function parseNumber(): boolean {
     const start = i
+    let num = ''
+    let invalid = false
+
     if (text[i] === '-') {
+      num += text[i]
       i++
+
+      if (!isDigit(text[i]) && atEndOfNumber()) {
+        // repair missing zero after minus like in "-.2" or "-"
+        num += '0'
+      }
+    }
+
+    if (text[i] === '0' && isDigit(text[i + 1])) {
+      // the number has leading zeros like "00123" or "001.23"
+      invalid = true
     }
 
     while (isDigit(text[i])) {
+      num += text[i]
       i++
     }
 
-    if (text[i] === '.' && (i > start || isDigit(text[i + 1]))) {
+    if (text[i] === '.') {
+      if (num === '' || num === '-') {
+        // repair missing leading zero before dot
+        num += '0'
+      }
+
+      num += text[i]
       i++
+
+      if (!isDigit(text[i])) {
+        // repair a truncated number like "2." into "2.0"
+        num += '0'
+      }
+
       while (isDigit(text[i])) {
+        num += text[i]
         i++
       }
     }
 
     if (i > start) {
       if (text[i] === 'e' || text[i] === 'E') {
+        if (num === '-') {
+          invalid = true
+        }
+
+        num += text[i]
         i++
+
         if (text[i] === '-' || text[i] === '+') {
+          num += text[i]
           i++
         }
+
+        if (!isDigit(text[i])) {
+          // repair a truncated number like "2e" into "2e0"
+          num += '0'
+        }
+
         while (isDigit(text[i])) {
+          num += text[i]
           i++
         }
       }
@@ -701,7 +742,7 @@ export function jsonrepair(text: string): string {
         return false
       }
 
-      output += repairNumber(text.slice(start, i))
+      output += invalid ? `"${text.substring(start, i)}"` : num
       return true
     }
 

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -1,5 +1,4 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
-import { repairNumber } from '../utils/numberUtils.js'
 import {
   isControlCharacter,
   isDelimiter,
@@ -862,28 +861,69 @@ export function jsonrepairCore({
    */
   function parseNumber(): boolean {
     const start = i
+    let num = ''
+    let invalid = false
+
     if (input.charAt(i) === '-') {
+      num += input.charAt(i)
       i++
+
+      if (!isDigit(input.charAt(i)) && atEndOfNumber()) {
+        num += '0'
+      }
+    }
+
+    if (input.charAt(i) === '0' && isDigit(input.charAt(i + 1))) {
+      // the number has leading zeros like "00123" or "001.23"
+      invalid = true
     }
 
     while (isDigit(input.charAt(i))) {
+      num += input.charAt(i)
       i++
     }
 
-    if (input.charAt(i) === '.' && (i > start || isDigit(input.charAt(i + 1)))) {
+    if (input.charAt(i) === '.') {
+      if (num === '' || num === '-') {
+        // repair missing leading zero before dot
+        num += '0'
+      }
+
+      num += input.charAt(i)
       i++
+
+      if (!isDigit(input.charAt(i))) {
+        // repair a truncated number like "2." into "2.0"
+        num += '0'
+      }
+
       while (isDigit(input.charAt(i))) {
+        num += input.charAt(i)
         i++
       }
     }
 
     if (i > start) {
       if (input.charAt(i) === 'e' || input.charAt(i) === 'E') {
+        if (num === '-') {
+          invalid = true
+        }
+
+        num += input.charAt(i)
         i++
+
         if (input.charAt(i) === '-' || input.charAt(i) === '+') {
+          num += input.charAt(i)
           i++
         }
+
+        if (!isDigit(input.charAt(i))) {
+          // repair a truncated number like "2e" into "2e0"
+          num += '0'
+        }
+
         while (isDigit(input.charAt(i))) {
+          num += input.charAt(i)
           i++
         }
       }
@@ -894,7 +934,7 @@ export function jsonrepairCore({
         return false
       }
 
-      output.push(repairNumber(input.substring(start, i)))
+      output.push(invalid ? `"${input.substring(start, i)}"` : num)
       return stack.update(Caret.afterValue)
     }
 

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -1,4 +1,5 @@
 import { JSONRepairError } from '../utils/JSONRepairError.js'
+import { repairNumber } from '../utils/numberUtils.js'
 import {
   isControlCharacter,
   isDelimiter,
@@ -863,69 +864,37 @@ export function jsonrepairCore({
     const start = i
     if (input.charAt(i) === '-') {
       i++
-      if (atEndOfNumber()) {
-        repairNumberEndingWithNumericSymbol(start)
-        return stack.update(Caret.afterValue)
-      }
-      if (!isDigit(input.charAt(i))) {
-        i = start
-        return false
-      }
     }
 
-    // Note that in JSON leading zeros like "00789" are not allowed.
-    // We will allow all leading zeros here though and at the end of parseNumber
-    // check against trailing zeros and repair that if needed.
-    // Leading zeros can have meaning, so we should not clear them.
     while (isDigit(input.charAt(i))) {
       i++
     }
 
-    if (input.charAt(i) === '.') {
+    if (input.charAt(i) === '.' && (i > start || isDigit(input.charAt(i + 1)))) {
       i++
-      if (atEndOfNumber()) {
-        repairNumberEndingWithNumericSymbol(start)
-        return stack.update(Caret.afterValue)
-      }
-      if (!isDigit(input.charAt(i))) {
-        i = start
-        return false
-      }
       while (isDigit(input.charAt(i))) {
         i++
       }
-    }
-
-    if (input.charAt(i) === 'e' || input.charAt(i) === 'E') {
-      i++
-      if (input.charAt(i) === '-' || input.charAt(i) === '+') {
-        i++
-      }
-      if (atEndOfNumber()) {
-        repairNumberEndingWithNumericSymbol(start)
-        return stack.update(Caret.afterValue)
-      }
-      if (!isDigit(input.charAt(i))) {
-        i = start
-        return false
-      }
-      while (isDigit(input.charAt(i))) {
-        i++
-      }
-    }
-
-    // if we're not at the end of the number by this point, allow this to be parsed as another type
-    if (!atEndOfNumber()) {
-      i = start
-      return false
     }
 
     if (i > start) {
-      // repair a number with leading zeros like "00789"
-      const num = input.substring(start, i)
-      const hasInvalidLeadingZero = /^0\d/.test(num)
+      if (input.charAt(i) === 'e' || input.charAt(i) === 'E') {
+        i++
+        if (input.charAt(i) === '-' || input.charAt(i) === '+') {
+          i++
+        }
+        while (isDigit(input.charAt(i))) {
+          i++
+        }
+      }
 
-      output.push(hasInvalidLeadingZero ? `"${num}"` : num)
+      // if we're not at the end of the number by this point, allow this to be parsed as another type
+      if (!atEndOfNumber()) {
+        i = start
+        return false
+      }
+
+      output.push(repairNumber(input.substring(start, i)))
       return stack.update(Caret.afterValue)
     }
 
@@ -1010,13 +979,6 @@ export function jsonrepairCore({
 
   function atEndOfNumber() {
     return input.isEnd(i) || isDelimiter(input.charAt(i)) || isWhitespace(input, i)
-  }
-
-  function repairNumberEndingWithNumericSymbol(start: number) {
-    // repair numbers cut off at the end
-    // this will only be called when we end after a '.', '-', or 'e' and does not
-    // change the number more than it needs to make it valid JSON
-    output.push(`${input.substring(start, i)}0`)
   }
 
   function throwInvalidCharacter(char: string) {

--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -1,0 +1,8 @@
+export function repairNumber(num: string): string {
+  return num
+    .replace(/^(0\d.*)$|^-[eE].*$/, (match) => `"${match}"`) // repair a number with leading zeros like "00789" and invalid values like "-e5"
+    .replace(/^\./, '0.') // repair a missing leading zero like in ".2"
+    .replace(/^-\./, '-0.') // repair a missing leading zero like in "-.2"
+    .replace(/\.$/, '.0') // repair a missing zero at the end like "2."
+    .replace(/([eE]|[eE][+-]|-)$/, (match) => `${match}0`) // repair a missing zero at the end like "2e" or "2e-" or "-"
+}

--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -1,8 +1,0 @@
-export function repairNumber(num: string): string {
-  return num
-    .replace(/^(0\d.*)$|^-[eE].*$/, (match) => `"${match}"`) // repair a number with leading zeros like "00789" and invalid values like "-e5"
-    .replace(/^\./, '0.') // repair a missing leading zero like in ".2"
-    .replace(/^-\./, '-0.') // repair a missing leading zero like in "-.2"
-    .replace(/\.$/, '.0') // repair a missing zero at the end like "2."
-    .replace(/([eE]|[eE][+-]|-)$/, (match) => `${match}0`) // repair a missing zero at the end like "2e" or "2e-" or "-"
-}


### PR DESCRIPTION
Fixes some of the cases issues from #171. Improves repairing invalid numbers, for example in cases like `[e]`, `[e5]`, `{"n": -05}`, `00.`, `-.3`.

The function `parseNumber` is rewritten in a more strict way by populating a new variable `num` with the parsed and repaired number, adding leading/trailing zeros where needed.