### PR TITLE
Fix: repair unquoted strings starting with a keyword

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,6 +65,13 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       assertRepair('true')
       assertRepair('false')
       assertRepair('null')
+
+      expect(jsonrepair('trueble')).toBe('"trueble"')
+      expect(jsonrepair('Trueble')).toBe('"Trueble"')
+      expect(jsonrepair('false_value')).toBe('"false_value"')
+      expect(jsonrepair('false$')).toBe('"false$"')
+      expect(jsonrepair('nullifiable')).toBe('"nullifiable"')
+      expect(jsonrepair('[truee')).toBe('["truee"]')
     })
 
     test('correctly handle strings equaling a JSON delimiter', () => {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -756,7 +756,7 @@ export function jsonrepair(text: string): string {
   }
 
   function parseKeyword(name: string, value: string): boolean {
-    if (text.slice(i, i + name.length) === name) {
+    if (text.slice(i, i + name.length) === name && !isFunctionNameChar(text[i + name.length])) {
       output += value
       i += name.length
       return true

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -949,7 +949,10 @@ export function jsonrepairCore({
   }
 
   function parseKeyword(name: string, value: string): boolean {
-    if (input.substring(i, i + name.length) === name) {
+    if (
+      input.substring(i, i + name.length) === name &&
+      !isFunctionNameChar(input.charAt(i + name.length))
+    ) {
       output.push(value)
       i += name.length
       return stack.update(Caret.afterValue)


### PR DESCRIPTION
Fixes an issue raised in #171: repairing a case like `[truee`. The also addresses keywords followed by word characters in general, like `[nullifiable` which is now repaired into `["nullifiable"]` instead of `[null,"ifiable"]`.