### PR TITLE
Fix: trailing-comma repair strips the parents containers comma

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -480,9 +480,10 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('[{"b":2\n]')).toBe('[{"b":2}\n]')
       expect(jsonrepair('[{"i":1{"i":2}]')).toBe('[{"i":1},{"i":2}]')
       expect(jsonrepair('[{"i":1,{"i":2}]')).toBe('[{"i":1},{"i":2}]')
+      expect(jsonrepair('[{{]')).toBe('[{},{}]')
     })
 
-    test('should remove a redundant closing bracket for an object', () => {
+    test('should remove a redundant closing brace for an object', () => {
       expect(jsonrepair('{"a": 1}}')).toBe('{"a": 1}')
       expect(jsonrepair('{"a": 1}}]}')).toBe('{"a": 1}')
       expect(jsonrepair('{"a": 1 }  }  ]  }  ')).toBe('{"a": 1 }        ')
@@ -501,6 +502,8 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('[[1,2,3,')).toBe('[[1,2,3]]')
       expect(jsonrepair('{\n"values":[1,2,3\n}')).toBe('{\n"values":[1,2,3]\n}')
       expect(jsonrepair('{\n"values":[1,2,3\n')).toBe('{\n"values":[1,2,3]}\n')
+      expect(jsonrepair('[1,[}]')).toBe('[1,[]]')
+      expect(jsonrepair('{"a": 1, "b": [}')).toBe('{"a": 1, "b": []}')
     })
 
     test('should strip MongoDB data types', () => {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -289,7 +289,6 @@ export function jsonrepair(text: string): string {
           parseWhitespaceAndSkipComments()
         } else {
           processedComma = true
-          initial = false
         }
 
         skipEllipsis()
@@ -304,7 +303,9 @@ export function jsonrepair(text: string): string {
             text[i] === undefined
           ) {
             // repair trailing comma
-            output = stripLastOccurrence(output, ',')
+            if (!initial) {
+              output = stripLastOccurrence(output, ',')
+            }
           } else {
             throwObjectKeyExpected()
           }
@@ -331,6 +332,8 @@ export function jsonrepair(text: string): string {
             throwColonExpected()
           }
         }
+
+        initial = false
       }
 
       if (text[i] === '}') {
@@ -369,8 +372,6 @@ export function jsonrepair(text: string): string {
             // repair missing comma
             output = insertBeforeLastWhitespace(output, ',')
           }
-        } else {
-          initial = false
         }
 
         skipEllipsis()
@@ -378,9 +379,13 @@ export function jsonrepair(text: string): string {
         const processedValue = parseValue()
         if (!processedValue) {
           // repair trailing comma
-          output = stripLastOccurrence(output, ',')
+          if (!initial) {
+            output = stripLastOccurrence(output, ',')
+          }
           break
         }
+
+        initial = false
       }
 
       if (text[i] === ']') {


### PR DESCRIPTION
Fixes an issue raised in #171: the trailing-comma repair strips the parents containers comma. This was only an issue in the regular `jsonrepair` function, not in the streaming implementation.

input | output before this fix (invalid) | output after this fix
--- | --- | ---
`jsonrepair('[{{]')` | `'[{}{}]'`  | `'[{},{}]'`
`jsonrepair('[1,[}]')` | `'[1[]]'` | `'[1,[]]'`
`jsonrepair('{"a": 1, "b": [}')` | `'{"a": 1 "b": []}'` | `'{"a": 1, "b": []}''`