### PR TITLE
Fix: infinite recursion when a string is followed by a backslash

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -283,6 +283,16 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(jsonrepair('"first\\\nsecond"')).toBe('"first\\nsecond"')
     })
 
+    test('should repair a backslash character outside of a string', () => {
+      const msg = 'Unexpected character "\\\\"'
+
+      expect(() => jsonrepair('["y"\\, "z"]')).toThrow(new JSONRepairError(msg, 4))
+      expect(() => jsonrepair('["y", "z"\\]')).toThrow(new JSONRepairError(msg, 9))
+      expect(() => jsonrepair('["y" \\, "z"]')).toThrow(new JSONRepairError(msg, 5))
+      expect(() => jsonrepair('"y"\\, "z"')).toThrow(new JSONRepairError(msg, 3))
+      expect(() => jsonrepair('{"a": "y"\\, "b"\\: "z"}')).toThrow(new JSONRepairError(msg, 9))
+    })
+
     test('should repair a missing object value', () => {
       expect(jsonrepair('{"a":}')).toBe('{"a":null}')
       expect(jsonrepair('{"a":,"b":2}')).toBe('{"a":null,"b":2}')

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -289,6 +289,7 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(() => jsonrepair('["y"\\, "z"]')).toThrow(new JSONRepairError(msg, 4))
       expect(() => jsonrepair('["y", "z"\\]')).toThrow(new JSONRepairError(msg, 9))
       expect(() => jsonrepair('["y" \\, "z"]')).toThrow(new JSONRepairError(msg, 5))
+      expect(() => jsonrepair('["y", "z"]\\')).toThrow(new JSONRepairError(msg, 10))
       expect(() => jsonrepair('"y"\\, "z"')).toThrow(new JSONRepairError(msg, 3))
       expect(() => jsonrepair('{"a": "y"\\, "b"\\: "z"}')).toThrow(new JSONRepairError(msg, 9))
     })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -290,6 +290,10 @@ describe.each(implementations)('jsonrepair [$name]', ({ jsonrepair }) => {
       expect(() => jsonrepair('["y", "z"\\]')).toThrow(new JSONRepairError(msg, 9))
       expect(() => jsonrepair('["y" \\, "z"]')).toThrow(new JSONRepairError(msg, 5))
       expect(() => jsonrepair('["y", "z"]\\')).toThrow(new JSONRepairError(msg, 10))
+      expect(() => jsonrepair('["y",\\\\ "z"]')).toThrow(new JSONRepairError(msg, 6))
+      expect(() => jsonrepair('[["y"],\\["z"]]')).toThrow(
+        new JSONRepairError('Unexpected character "["', 8)
+      )
       expect(() => jsonrepair('"y"\\, "z"')).toThrow(new JSONRepairError(msg, 3))
       expect(() => jsonrepair('{"a": "y"\\, "b"\\: "z"}')).toThrow(new JSONRepairError(msg, 9))
     })

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -443,11 +443,14 @@ export function jsonrepair(text: string): string {
    *   stop index detected in the first iteration.
    */
   function parseString(stopAtDelimiter = false, stopAtIndex = -1): boolean {
-    let skipEscapeChars = text[i] === '\\'
+    const skipEscapeChars = text[i] === '\\'
     if (skipEscapeChars) {
       // repair: remove the first escape character
       i++
-      skipEscapeChars = true
+
+      if (!isQuote(text[i])) {
+        throwUnexpectedCharacter()
+      }
     }
 
     if (isQuote(text[i])) {

--- a/src/regular/jsonrepair.ts
+++ b/src/regular/jsonrepair.ts
@@ -524,6 +524,10 @@ export function jsonrepair(text: string): string {
             return true
           }
 
+          if (text[i] === '\\') {
+            throwUnexpectedCharacter()
+          }
+
           const iPrevChar = prevNonWhitespaceIndex(iQuote - 1)
           const prevChar = text.charAt(iPrevChar)
 

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -637,11 +637,14 @@ export function jsonrepairCore({
    *   stop index detected in the first iteration.
    */
   function parseString(stopAtDelimiter = false, stopAtIndex = -1): boolean {
-    let skipEscapeChars = input.charAt(i) === '\\'
+    const skipEscapeChars = input.charAt(i) === '\\'
     if (skipEscapeChars) {
       // repair: remove the first escape character
       i++
-      skipEscapeChars = true
+
+      if (!isQuote(input.charAt(i))) {
+        throwUnexpectedCharacter()
+      }
     }
 
     if (isQuote(input.charAt(i))) {

--- a/src/streaming/core.ts
+++ b/src/streaming/core.ts
@@ -715,6 +715,10 @@ export function jsonrepairCore({
             return stack.update(Caret.afterValue)
           }
 
+          if (input.charAt(i) === '\\') {
+            throwUnexpectedCharacter()
+          }
+
           const iPrevChar = prevNonWhitespaceIndex(iQuote - 1)
           const prevChar = input.charAt(iPrevChar)
 


### PR DESCRIPTION
Fix #170: infinite recursion when a string is followed by a backslash.

In this PR I've worked out a fix which throws an exception when a backslash is encountered outside of a string, for example for the input `jsonrepair('["y"\\, "z"]')`.

It would be neat to remove the backslash instead of throwing an error. That requires more work though, it should handle cases of a backslash anywhere outside of a string, not just after a string.